### PR TITLE
Wide Sweep Ability fix

### DIFF
--- a/src/main/java/com/oblivioussp/spartanweaponry/item/ItemScythe.java
+++ b/src/main/java/com/oblivioussp/spartanweaponry/item/ItemScythe.java
@@ -27,4 +27,27 @@ public class ItemScythe extends ItemSwordBase
 	{
 		this(unlocName, externalModId, material);
 	}
+
+	
+	/**
+	 * Called when the player Left Clicks (attacks) an entity.
+	 * Processed before damage is done, if return value is true further processing is canceled
+	 * and the entity is not attacked.
+	 *
+	 * @param stack The Item being used
+	 * @param player The player that is attacking
+	 * @param entity The entity being attacked
+	 * @return True to cancel the rest of the interaction.
+	 */
+	@Override
+	public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity targetEntity)
+	{
+		return ModSpartanWeaponry.isRLCombatLoaded ? false : WeaponHelper.inflictAttackDamage(this, stack, player, targetEntity, WeaponProperties.WIDE_SWEEP.getMagnitude());
+	}
+
+	@Override
+	public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+	{
+		return enchantment != Enchantments.SWEEPING && super.canApplyAtEnchantingTable(stack, enchantment);
+	}
 }

--- a/src/main/java/com/oblivioussp/spartanweaponry/util/WeaponHelper.java
+++ b/src/main/java/com/oblivioussp/spartanweaponry/util/WeaponHelper.java
@@ -183,7 +183,7 @@ public class WeaponHelper
                         	AxisAlignedBB sweepBox = targetEntity.getEntityBoundingBox().grow(1.0D, 0.25D, 1.0D);
                         	
                         	if(sweepProp.getType() == WeaponProperties.PROPERTY_TYPE_WIDE_SWEEP)
-                        		sweepBox.grow(ConfigHandler.wideSweepAdditionalRange);
+                        		sweepBox = sweepBox.grow(ConfigHandler.wideSweepAdditionalRange);
                         	
                             for (EntityLivingBase entitylivingbase : player.world.getEntitiesWithinAABB(EntityLivingBase.class, sweepBox))
                             {


### PR DESCRIPTION
Fixes #145 by making ItemScythe call the WeaponHelper class like other weapons do, along with a small fix to make the range increase as intended in the WeaponHelper class itself.