### PR TITLE
Tiny API Fix - recipeGlaive and recipeQuarterstaff are infinitely recursive

### DIFF
--- a/src/main/java/com/oblivioussp/spartanweaponry/api/data/recipe/RecipeProviderHelper.java
+++ b/src/main/java/com/oblivioussp/spartanweaponry/api/data/recipe/RecipeProviderHelper.java
@@ -743,7 +743,7 @@ public class RecipeProviderHelper
 	 */
 	public static void recipeGlaive(Consumer<FinishedRecipe> consumer, ItemLike pole, TagKey<Item> material, ItemLike result, String hasItemCriterionName)
 	{
-		recipeGlaive(consumer, pole, material, result, hasItemCriterionName);
+		recipeGlaive(consumer, pole, material, result, hasItemCriterionName, "");
 	}
 
 	/**
@@ -774,7 +774,7 @@ public class RecipeProviderHelper
 	 */
 	public static void recipeQuarterstaff(Consumer<FinishedRecipe> consumer, ItemLike pole, TagKey<Item> material, ItemLike result, String hasItemCriterionName)
 	{
-		recipeQuarterstaff(consumer, pole, material, result, hasItemCriterionName);
+		recipeQuarterstaff(consumer, pole, material, result, hasItemCriterionName, "");
 	}
 
 	/**


### PR DESCRIPTION
If either recipeGlaive or recipeQuarterstaff are called, an immediate overflow will occur, and further recipe generation grinds to a halt.  Simple tiny fix, but it'll allow any mods using Spartan Weaponry Addon Toolkit to successfully generate Glaive, Quarterstaff, and Scythe recipes (Scythe recipes are registered after Glaive recipes with Toolkit, so they're cut off during registration; methods work fine though)