### PR TITLE
Use thread safe random

### DIFF
--- a/src/main/java/com/oblivioussp/spartanweaponry/util/ItemRandomizer.java
+++ b/src/main/java/com/oblivioussp/spartanweaponry/util/ItemRandomizer.java
@@ -11,7 +11,7 @@ public class ItemRandomizer
 {
 	public static ItemStack generate(Level level, List<Item> items)
 	{
-		float weaponRand = level.random.nextFloat();
+		float weaponRand = level.getRandom().nextFloat();
 		float divider = 1.0f / items.size();
 		int idx = Mth.floor(weaponRand / divider);
 		idx = idx > items.size() - 1 ? items.size() - 1 : idx;


### PR DESCRIPTION
Replace level.random with level.getRandom() to be thread safe.
This fixes a crash with c2me or other multi threaded chunk generators.